### PR TITLE
bug: deal with python module named index.py

### DIFF
--- a/src/mkdocs_api_autonav/plugin.py
+++ b/src/mkdocs_api_autonav/plugin.py
@@ -140,19 +140,19 @@ class AutoAPIPlugin(BasePlugin[PluginConfig]):  # type: ignore [no-untyped-call]
                 # Check direct path exclusions
                 mod_path = ".".join(name_parts)
                 if any(mod_path == x or mod_path.startswith(x) for x in exclude_paths):
-                    logger.info("Excluding module (path match): %s", mod_path)
+                    logger.info("Excluding   %r due to config.exclude", mod_path)
                     continue
 
                 # Check regex exclusions
                 if any(pattern.search(mod_path) for pattern in exclude_patterns):
-                    logger.info("Excluding module (regex match): %s", mod_path)
+                    logger.info("Excluding   %r due to config.exclude", mod_path)
                     continue
 
                 # create the actual markdown that will go into the virtual file
                 content = self._module_markdown(name_parts)
 
                 # generate a mkdocs File object and add it to the collection
-                logger.info("Writing virtual file: %s", docs_path)
+                logger.info("Documenting %r in virtual file: %s", mod_path, docs_path)
                 file = File.generated(config, src_uri=docs_path, content=content)
                 if file.src_uri in files.src_uris:  # pragma: no cover
                     files.remove(file)
@@ -233,6 +233,11 @@ def _iter_modules(
             parts = parts[:-1]
             doc_path = doc_path.with_name("index.md")
             full_doc_path = full_doc_path.with_name("index.md")
+        if parts[-1] == "index":
+            # deal with the special case of a module named 'index.py'
+            # we don't want to name it index.md, since that is a special
+            # name for a directory index
+            full_doc_path = full_doc_path.with_name("index_py.md")
 
         yield parts, str(full_doc_path)
 

--- a/tests/test_mkdocs_api_autonav.py
+++ b/tests/test_mkdocs_api_autonav.py
@@ -72,6 +72,7 @@ def test_build(repo1: Path) -> None:
     assert (sub_sub / "index.html").is_file()
     assert not any(lib.rglob("*exclude_me*"))
 
+
 def test_build_exclude_re(repo1: Path) -> None:
     mkdocs_yml = repo1 / "mkdocs.yml"
     cfg = cfg_dict()
@@ -220,3 +221,18 @@ def test_multi_package(repo1: Path, strict: bool, nav: dict) -> None:
     mkdocs_yml.write_text(yaml.safe_dump(cfg_with_nav))
     _build_command(str(mkdocs_yml))
     assert (ref := repo1 / "site" / "reference").is_dir()
+
+
+def test_index_py_module(repo1: Path) -> None:
+    """Test the edge case of a module named index.py"""
+    cfg = cfg_dict()
+    repo1.joinpath("src", "my_library", "index.py").touch()
+    mkdocs_yml = repo1 / "mkdocs.yml"
+    mkdocs_yml.write_text(yaml.safe_dump(cfg))
+    _build_command(str(mkdocs_yml))
+
+    assert (ref := repo1 / "site" / "reference").is_dir()
+    assert (lib := ref / "my_library").is_dir()
+    assert (lib / "index.html").is_file()
+    assert (sub_mod := lib / "index_py").is_dir()
+    assert (sub_mod / "index.html").is_file()


### PR DESCRIPTION
This deals with an edge case I ran into when a python module is named `index.py` ... we don't want it to conflict with an `__init__.py` (which is generated at `index.md`)... so we put it at `index_py.md`