### PR TITLE
Enhance navigation by flattening single-page sections in auto-generat…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "mkdocs-awesome-nav>=3.1.1 ; python_full_version >= '3.10' and python_full_version < '3.14'",
+    "mkdocs-material>=9.6.19",
 ]
 dev = [
     { include-group = "test" },


### PR DESCRIPTION
possible fix to #32 


### Why Material Theme Doesn't Have This Problem

Material detects when a section has an index page (is_index=True for paths like reference/gamma/index.md) and uses its URL instead of #.

Default MkDocs Theme (mkdocs/themes/mkdocs/nav-sub.html:7):
```
{%- else %}
  <li class="dropdown-submenu">
    <a href="#" class="dropdown-item">{{ nav_item.title }}</a>  <!-- Always href="#" -->
```

Material Theme:

```
<!-- Detect index pages in sections -->
{% for item in nav_item.children %}
  {% if item.is_index and _.index is none %}
    {% set _.index = item %}
  {% endif %}
{% endfor %}

<!-- Use index page URL when available -->
{% if index %}
  <a href="{{ index.url | url }}" class="md-nav__link">  <!-- Direct link! -->

```

### The Fix here

Added `_flatten_single_page_sections()` method in `plugin.py:240-291` that:
1. Detects sections containing only a single page (e.g., modules with just __init__.py)
2. Flattens them by replacing the section with the page directly
3. Applies proper module prefix symbols to page titles
4. Runs before _fix_nav_item() during auto-nav processing